### PR TITLE
Use `strerror_r` for thread-safety

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod test {
             let res = &buf.s[.. buf.len];
             assert!(res.len() > 5);
             let end = res.chars().last().unwrap();
-            assert!(end.is_ascii_alphanumeric() && !end.is_whitespace());
+            assert!(end.is_ascii_alphanumeric() && !end.is_whitespace(), "Invalid message: '{}'", res);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ mod test {
             let res = &buf.s[.. buf.len];
             assert!(res.len() > 5);
             let end = res.chars().last().unwrap();
-            assert!(end.is_ascii_alphanumeric() && !end.is_whitespace(), "Invalid message: '{}'", res);
+            assert!(end.is_ascii_alphanumeric() && !end.is_whitespace() || end == '.', "Invalid message: '{}'", res);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,17 +87,26 @@ mod test {
         errno() == Errno(e)
     }
 
-    #[quickcheck]
-    fn error_display(e: i32) -> bool {
-        if e == 0 { return true; }
-        let mut buf = [0; 1024];
-        let buf = str::from_utf8_mut(&mut buf[..]).unwrap();
-        let mut buf = Buf { s: buf, len: 0 };
-        write!(&mut buf, "{}", Errno(e)).unwrap();
-        let res = &buf.s[.. buf.len];
-        assert!(res.len() > 5);
-        let end = res.chars().last();
-        end.is_some() && end.unwrap().is_ascii_alphanumeric() && !end.unwrap().is_whitespace()
+    #[test]
+    fn error_display() {
+        let valid_errnos = [
+            libc::E2BIG,
+            libc::EACCES,
+            libc::EADDRINUSE,
+            libc::EADDRNOTAVAIL,
+            libc::EAFNOSUPPORT,
+            libc::EAGAIN,
+        ];
+        for errno in valid_errnos {
+            let mut buf = [0; 1024];
+            let buf = str::from_utf8_mut(&mut buf[..]).unwrap();
+            let mut buf = Buf { s: buf, len: 0 };
+            write!(&mut buf, "{}", Errno(errno)).unwrap();
+            let res = &buf.s[.. buf.len];
+            assert!(res.len() > 5);
+            let end = res.chars().last().unwrap();
+            assert!(end.is_ascii_alphanumeric() && !end.is_whitespace());
+        }
     }
 
     #[cfg(not(target_os="macos"))]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -7,6 +7,8 @@ use libc::{CODESET, E2BIG, c_char, c_int, nl_langinfo, strlen};
 use libc::{iconv, iconv_open, iconv_close, iconv_t};
 
 extern "C" {
+    // Avoid GNU strerror_r on Linux and Newlib systems
+    #[cfg_attr(any(target_os = "linux", target_env = "newlib"), link_name = "__xpg_strerror_r")]
     fn strerror_r(errnum: c_int, buf: *mut c_char, buflen: libc::size_t) -> c_int;
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -105,9 +105,7 @@ pub fn errno_fmt(e: i32, f: &mut Formatter) -> fmt::Result {
     // 128 bytes should be long enough for all error messages
     const BUF_SIZE: usize = 128;
 
-    // The cast is neessary for portability, since c_char is not necessarily i8.
-    #[allow(clippy::unnecessary_cast)]
-    let mut buf = [0 as c_char; BUF_SIZE];
+    let mut buf: [c_char; BUF_SIZE] = [0; BUF_SIZE];
     if unsafe { strerror_r(e, buf.as_mut_ptr(), BUF_SIZE) } < 0 {
         return Err(fmt::Error);
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -108,12 +108,12 @@ pub fn errno_fmt(e: i32, f: &mut Formatter) -> fmt::Result {
     // "Proof": https://github.com/rust-lang/rust/blob/5176945ad49005b82789be5700f5ae0e6efe5481/library/std/src/sys/unix/os.rs#L31
     const BUF_SIZE: usize = 128;
 
-    let mut buf: [c_char; BUF_SIZE] = [0; BUF_SIZE];
-    if unsafe { strerror_r(e, buf.as_mut_ptr(), BUF_SIZE) } != 0 {
+    let mut buf: [u8; BUF_SIZE] = [0; BUF_SIZE];
+    if unsafe { strerror_r(e, buf.as_mut_ptr() as *mut c_char, BUF_SIZE) } != 0 {
         return Err(fmt::Error);
     }
 
-    let msg = unsafe { slice::from_raw_parts(buf.as_ptr().cast::<u8>(), strlen(buf.as_ptr())) };
+    let msg = unsafe { slice::from_raw_parts(buf.as_ptr(), strlen(buf.as_ptr() as *const c_char)) };
 
     localized_msg_fmt(msg, f)
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -105,6 +105,7 @@ fn localized_msg_fmt(msg: &[u8], f: &mut Formatter) -> fmt::Result {
 
 pub fn errno_fmt(e: i32, f: &mut Formatter) -> fmt::Result {
     // 128 bytes should be long enough for all error messages
+    // "Proof": https://github.com/rust-lang/rust/blob/5176945ad49005b82789be5700f5ae0e6efe5481/library/std/src/sys/unix/os.rs#L31
     const BUF_SIZE: usize = 128;
 
     let mut buf: [c_char; BUF_SIZE] = [0; BUF_SIZE];

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -108,7 +108,7 @@ pub fn errno_fmt(e: i32, f: &mut Formatter) -> fmt::Result {
     const BUF_SIZE: usize = 128;
 
     let mut buf: [c_char; BUF_SIZE] = [0; BUF_SIZE];
-    if unsafe { strerror_r(e, buf.as_mut_ptr(), BUF_SIZE) } < 0 {
+    if unsafe { strerror_r(e, buf.as_mut_ptr(), BUF_SIZE) } != 0 {
         return Err(fmt::Error);
     }
 


### PR DESCRIPTION
Using `strerror` is unsound because `errno_fmt` could be called from multiple threads, and `strerror` is MT-Unsafe.